### PR TITLE
Updates dependencies, plugin-meta

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,4 +109,7 @@ function now () {
   return (ts[0] * 1e3) + (ts[1] / 1e6)
 }
 
-module.exports = fp(underPressure, { fastify: '>=0.27.0' })
+module.exports = fp(underPressure, {
+  fastify: '>=0.39.0',
+  name: 'under-pressure'
+})

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
   "dependencies": {
-    "fastify-plugin": "^0.2.0"
+    "fastify-plugin": "^0.2.1"
   },
   "devDependencies": {
-    "fastify": "^0.36.0",
+    "fastify": "^0.39.0",
     "simple-get": "^2.7.0",
     "standard": "^10.0.3",
-    "tap": "^11.0.0"
+    "tap": "^11.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -21,7 +21,8 @@ test('Should return 503 on maxEventLoopDelay', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    process.nextTick(() => sleep(500))
+    // Increased to prevent Travis to fail
+    process.nextTick(() => sleep(1000))
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port


### PR DESCRIPTION
- updates to fastify@0.39 #8
- updates to tap@11.0.1 #5
- updates to fastify-plugin@0.2.1
- updates plugin-meta see: https://github.com/fastify/fastify-plugin/issues/17#issuecomment-355972265

Sorry, for this. Any idea why Travis fails? 
I ran it on node@4,6,8 in my dev environment and all was green.
Increasing timeout seems to make it work on node@4, but i rather wait for an answer than increase the number of failed tests.