### PR TITLE
(Issue #42) Additional route options are not passed when exposing status route

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fastify.register(require('under-pressure'), {
         someAttr: 'value'
       }
     },
-    route: '/alive' // If you also want to set a custom route path and pass options
+    url: '/alive' // If you also want to set a custom route path and pass options
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -68,12 +68,19 @@ If needed you can pass `{ exposeStatusRoute: true }` and `under-pressure` will e
 
 If you need the change the exposed route path, you can pass `{ exposeStatusRoute: '/alive' }` options.
 
-The options object will be passed down to the route registration method to allow passing of route configuration options.
+If you need to pass options to the status route, such as logLevel or custom configuration you can pass an object,
 ```js
 fastify.register(require('under-pressure'), {
   maxEventLoopDelay: 1000,
-  exposeStatusRoute: true,
-  logLevel: 'debug'
+  exposeStatusRoute: {
+    routeOpts: {
+      logLevel: 'debug',
+      config: {
+        someAttr: 'value'
+      }
+    },
+    route: '/alive' // If you also want to set a custom route path and pass options
+  }
 })
 ```
 The above example will set the `logLevel` value for the `/status` route be `debug`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ If needed you can pass `{ exposeStatusRoute: true }` and `under-pressure` will e
 
 If you need the change the exposed route path, you can pass `{ exposeStatusRoute: '/alive' }` options.
 
+The options object will be passed down to the route registration method to allow passing of route configuration options.
+```js
+fastify.register(require('under-pressure'), {
+  maxEventLoopDelay: 1000,
+  exposeStatusRoute: true,
+  logLevel: 'debug'
+})
+```
+The above example will set the `logLevel` value for the `/status` route be `debug`.
 
 #### Custom health checks
 If needed you can pass a custom `healthCheck` property which is an async function and `under-pressure` will allow you to check the status of other components of your service.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function underPressure (fastify, opts) {
   if (opts.exposeStatusRoute) {
     fastify.route({
       ...opts.exposeStatusRoute.routeOpts,
-      url: opts.exposeStatusRoute.route || '/status',
+      url: opts.exposeStatusRoute.route,
       method: 'GET',
       schema: {
         response: {
@@ -89,10 +89,10 @@ async function underPressure (fastify, opts) {
     if (!opts) {
       return false
     }
-    const route = typeof opts === 'string' ? opts : '/status'
-    opts = typeof opts === 'object' ? opts : {}
-    opts.route = opts.route || route
-    return opts
+    if (typeof opts === 'string') {
+      return { route: opts }
+    }
+    return Object.assign({ route: '/status' }, opts)
   }
 
   function updateMemoryUsage () {

--- a/index.js
+++ b/index.js
@@ -52,10 +52,12 @@ async function underPressure (fastify, opts) {
   fastify.decorate('memoryUsage', memoryUsage)
   fastify.addHook('onClose', onClose)
 
+  opts.exposeStatusRoute = mapExposeStatusRoute(opts.exposeStatusRoute)
+
   if (opts.exposeStatusRoute) {
     fastify.route({
-      ...opts,
-      url: opts.exposeStatusRoute === true ? '/status' : opts.exposeStatusRoute,
+      ...opts.exposeStatusRoute.routeOpts,
+      url: opts.exposeStatusRoute.route || '/status',
       method: 'GET',
       schema: {
         response: {
@@ -82,6 +84,16 @@ async function underPressure (fastify, opts) {
   const retryAfter = opts.retryAfter || 10
 
   fastify.addHook('onRequest', onRequest)
+
+  function mapExposeStatusRoute (opts) {
+    if (!opts) {
+      return false
+    }
+    const route = typeof opts === 'string' ? opts : '/status'
+    opts = typeof opts === 'object' ? opts : {}
+    opts.route = opts.route || route
+    return opts
+  }
 
   function updateMemoryUsage () {
     var mem = process.memoryUsage()

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ async function underPressure (fastify, opts) {
 
   if (opts.exposeStatusRoute) {
     fastify.route({
+      ...opts,
       url: opts.exposeStatusRoute === true ? '/status' : opts.exposeStatusRoute,
       method: 'GET',
       schema: {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function underPressure (fastify, opts) {
   if (opts.exposeStatusRoute) {
     fastify.route({
       ...opts.exposeStatusRoute.routeOpts,
-      url: opts.exposeStatusRoute.route,
+      url: opts.exposeStatusRoute.url,
       method: 'GET',
       schema: {
         response: {
@@ -90,9 +90,9 @@ async function underPressure (fastify, opts) {
       return false
     }
     if (typeof opts === 'string') {
-      return { route: opts }
+      return { url: opts }
     }
-    return Object.assign({ route: '/status' }, opts)
+    return Object.assign({ url: '/status' }, opts)
   }
 
   function updateMemoryUsage () {

--- a/test.js
+++ b/test.js
@@ -274,14 +274,14 @@ test('Expose status route with additional route options', t => {
         logLevel: 'silent',
         config: customConfig
       },
-      route: '/alive'
+      url: '/alive'
     }
   })
 
   fastify.addHook('onRoute', (routeOptions) => {
     fastify.server.unref()
     process.nextTick(() => sleep(500))
-    t.strictEqual(routeOptions.path, '/alive')
+    t.strictEqual(routeOptions.url, '/alive')
     t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
     t.deepEqual(routeOptions.config, customConfig, 'config not set')
     fastify.close()
@@ -290,7 +290,7 @@ test('Expose status route with additional route options', t => {
   fastify.listen()
 })
 
-test('Expose status route with additional route options and default route', t => {
+test('Expose status route with additional route options and default url', t => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -304,7 +304,7 @@ test('Expose status route with additional route options and default route', t =>
   fastify.addHook('onRoute', (routeOptions) => {
     fastify.server.unref()
     process.nextTick(() => sleep(500))
-    t.strictEqual(routeOptions.path, '/status')
+    t.strictEqual(routeOptions.url, '/status')
     t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
     fastify.close()
   })

--- a/test.js
+++ b/test.js
@@ -90,7 +90,6 @@ test('Should return 503 on maxRssBytes', t => {
   fastify.listen(0, (err, address) => {
     t.error(err)
     fastify.server.unref()
-
     process.nextTick(() => sleep(500))
     sget({
       method: 'GET',
@@ -285,6 +284,28 @@ test('Expose status route with additional route options', t => {
     t.strictEqual(routeOptions.path, '/alive')
     t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
     t.deepEqual(routeOptions.config, customConfig, 'config not set')
+    fastify.close()
+  })
+
+  fastify.listen()
+})
+
+test('Expose status route with additional route options and default route', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.register(underPressure, {
+    exposeStatusRoute: {
+      routeOpts: {
+        logLevel: 'silent'
+      }
+    }
+  })
+  fastify.addHook('onRoute', (routeOptions) => {
+    fastify.server.unref()
+    process.nextTick(() => sleep(500))
+    t.strictEqual(routeOptions.path, '/status')
+    t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
     fastify.close()
   })
 

--- a/test.js
+++ b/test.js
@@ -270,15 +270,19 @@ test('Expose status route with additional route options', t => {
   }
   const fastify = Fastify()
   fastify.register(underPressure, {
-    exposeStatusRoute: true,
-    logLevel: 'silent',
-    config: customConfig
+    exposeStatusRoute: {
+      routeOpts: {
+        logLevel: 'silent',
+        config: customConfig
+      },
+      route: '/alive'
+    }
   })
 
   fastify.addHook('onRoute', (routeOptions) => {
     fastify.server.unref()
     process.nextTick(() => sleep(500))
-    t.strictEqual(routeOptions.path, '/status')
+    t.strictEqual(routeOptions.path, '/alive')
     t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
     t.deepEqual(routeOptions.config, customConfig, 'config not set')
     fastify.close()

--- a/test.js
+++ b/test.js
@@ -262,6 +262,31 @@ test('Expose custom status route', t => {
   })
 })
 
+test('Expose status route with additional route options', t => {
+  t.plan(3)
+
+  const customConfig = {
+    customVal: 'someVal'
+  }
+  const fastify = Fastify()
+  fastify.register(underPressure, {
+    exposeStatusRoute: true,
+    logLevel: 'silent',
+    config: customConfig
+  })
+
+  fastify.addHook('onRoute', (routeOptions) => {
+    fastify.server.unref()
+    process.nextTick(() => sleep(500))
+    t.strictEqual(routeOptions.path, '/status')
+    t.strictEqual(routeOptions.logLevel, 'silent', 'log level not set')
+    t.deepEqual(routeOptions.config, customConfig, 'config not set')
+    fastify.close()
+  })
+
+  fastify.listen()
+})
+
 test('Custom health check', t => {
   t.plan(6)
 


### PR DESCRIPTION

Fixes #42 

Pass the options object down to the route registration when exposing the health check endpoint

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
