### PR TITLE
feat: use monitorEventLoopDelay where available

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ fastify.register(require('under-pressure'), {
   healthCheckInterval: 500
 })
 ```
+<a name="sample-interval"></a>
+#### Sample interval
+
+You can set a custom value for sampling the metrics returned by `memoryUsage` using the `sampleInterval` option, which accepts a number that represents the interval in milliseconds.
+
+The default value is different depending on which Node version is used. On version 8 and 10 it is `5`, while on version 11.10.0 and up it is `1000`. This difference is due to the fact that from version 11.10.0 the event loop delay can be sampled with [`monitorEventLoopDelay`](https://nodejs.org/docs/latest-v12.x/api/perf_hooks.html#perf_hooks_perf_hooks_monitoreventloopdelay_options) and this allows to increase the interval value.
+
+```js
+const fastify = require('fastify')()
+
+fastify.register(require('under-pressure'), {
+  sampleInterval: <your custom sample interval in ms>
+})
+
+
+```
 
 <a name="acknowledgements"></a>
 ## Acknowledgements


### PR DESCRIPTION
Use the `monitorEventLoopDelay` API available from Node 12 and up to
sample the event loop delay.
When available, the resolution is hard-coded at 10 ms and all the values of the
`sampleInterval` option lower than that are ignored and its value is set to
10. Also, when using `monitorEventLoopDelay` the default sampleInterval is set
to 1000 since it used only to gather memory metrics.
Tests have been modified to:
1. do not rely on the event loop delay where is not necessary to trigger
    503 because it has been proven unreliable (maybe because I am using the mean
    value from the `Histogram` returned by `monitorEventLoopDelay`)
2. add a `wait` function in tests to wait for that event loop samples get
    taken and to wait for the increased default `sampleInterval`


Fix #18.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
