### PR TITLE
feat(expose new metric): exposes eventLoopUtilizationVal to memoryUsage function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ const fastify = require('fastify')()
 fastify.register(require('under-pressure'), {
   maxEventLoopDelay: 1000,
   maxHeapUsedBytes: 100000000,
-  maxRssBytes: 100000000
+  maxRssBytes: 100000000,
+  maxEventLoopUtilization:1
 })
 
 fastify.get('/', (req, reply) => {
@@ -66,13 +67,15 @@ You can also configure custom Error instance `under-pressure` will throw.
 })
 ```
 
-The default value for `maxEventLoopDelay`, `maxHeapUsedBytes` and `maxRssBytes` is `0`.  
+The default value for `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` is `0`.  
 If the value is `0` the check will not be performed.
+
+Since [`eventLoopUtilization`](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_utilization1_utilization2) is only available in Node version 14.0.0 and 12.19.0 the check will be disbaled in other versions.
 
 Thanks to the encapsulation model of Fastify, you can selectively use this plugin in some subset of routes or even with different thresholds in different plugins.
 
 #### `memoryUsage`
-This plugin also exposes a function that will tell you the current values of `heapUsed`, `rssBytes` and `eventLoopDelay`.
+This plugin also exposes a function that will tell you the current values of `heapUsed`, `rssBytes`, `eventLoopDelay` and `eventLoopUtilizationVal`.
 ```js
 console.log(fastify.memoryUsage())
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 
 Measure process load with automatic handling of *"Service Unavailable"* plugin for Fastify.
-It can check `maxEventLoopDelay`, `maxHeapUsedBytes` and `maxRssBytes` values.
+It can check `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` values.
 You can also specify custom health check, to verify the status of
 external resources.
 
@@ -30,7 +30,7 @@ fastify.register(require('under-pressure'), {
   maxEventLoopDelay: 1000,
   maxHeapUsedBytes: 100000000,
   maxRssBytes: 100000000,
-  maxEventLoopUtilization:1
+  maxEventLoopUtilization:0.98
 })
 
 fastify.get('/', (req, reply) => {
@@ -75,7 +75,7 @@ Since [`eventLoopUtilization`](https://nodejs.org/api/perf_hooks.html#perf_hooks
 Thanks to the encapsulation model of Fastify, you can selectively use this plugin in some subset of routes or even with different thresholds in different plugins.
 
 #### `memoryUsage`
-This plugin also exposes a function that will tell you the current values of `heapUsed`, `rssBytes`, `eventLoopDelay` and `eventLoopUtilizationVal`.
+This plugin also exposes a function that will tell you the current values of `heapUsed`, `rssBytes`, `eventLoopDelay` and `eventLoopUtilized`.
 ```js
 console.log(fastify.memoryUsage())
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare namespace underPressure {
 
 declare module "fastify" {
   interface FastifyInstance {
-    memoryUsage(): { heapUsed: number; rssBytes: number; eventLoopDelay: number };
+    memoryUsage(): { heapUsed: number; rssBytes: number; eventLoopDelay: number; eventLoopUtilizationVal: number };
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare namespace underPressure {
 
 declare module "fastify" {
   interface FastifyInstance {
-    memoryUsage(): { heapUsed: number; rssBytes: number; eventLoopDelay: number; eventLoopUtilizationVal: number };
+    memoryUsage(): { heapUsed: number; rssBytes: number; eventLoopDelay: number; eventLoopUtilized: number };
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function underPressure (fastify, opts) {
   let lastCheck
   let histogram
   let elu
-  let eventLoopUtilizationVal = 0
+  let eventLoopUtilized = 0
 
   if (monitorEventLoopDelay) {
     histogram = monitorEventLoopDelay({ resolution })
@@ -139,9 +139,9 @@ async function underPressure (fastify, opts) {
 
   function updateEventLoopUtilization () {
     if (elu) {
-      eventLoopUtilizationVal = eventLoopUtilization(elu).utilization
+      eventLoopUtilized = eventLoopUtilization(elu).utilization
     } else {
-      eventLoopUtilizationVal = 0
+      eventLoopUtilized = 0
     }
   }
 
@@ -174,7 +174,7 @@ async function underPressure (fastify, opts) {
       return
     }
 
-    if (checkMaxEventLoopUtilization && eventLoopUtilizationVal > maxEventLoopUtilization) {
+    if (checkMaxEventLoopUtilization && eventLoopUtilized > maxEventLoopUtilization) {
       sendError(reply, next)
       return
     }
@@ -192,7 +192,7 @@ async function underPressure (fastify, opts) {
       eventLoopDelay,
       rssBytes,
       heapUsed,
-      eventLoopUtilizationVal
+      eventLoopUtilized
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -191,7 +191,8 @@ async function underPressure (fastify, opts) {
     return {
       eventLoopDelay,
       rssBytes,
-      heapUsed
+      heapUsed,
+      eventLoopUtilizationVal
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -251,19 +251,21 @@ test('Custom error instance', t => {
 })
 
 test('memoryUsage name space', t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = Fastify()
   fastify.register(underPressure, {
     maxEventLoopDelay: 1000,
     maxHeapUsedBytes: 100000000,
-    maxRssBytes: 100000000
+    maxRssBytes: 100000000,
+    maxEventLoopUtilization: 0.85
   })
 
   fastify.get('/', (req, reply) => {
     t.true(fastify.memoryUsage().eventLoopDelay > 0)
     t.true(fastify.memoryUsage().heapUsed > 0)
     t.true(fastify.memoryUsage().rssBytes > 0)
+    t.true(fastify.memoryUsage().eventLoopUtilizationVal >= 0)
     reply.send({ hello: 'world' })
   })
 
@@ -293,7 +295,7 @@ test('memoryUsage name space', t => {
 })
 
 test('memoryUsage name space (without check)', t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = Fastify()
   fastify.register(underPressure)
@@ -302,6 +304,7 @@ test('memoryUsage name space (without check)', t => {
     t.true(fastify.memoryUsage().eventLoopDelay > 0)
     t.true(fastify.memoryUsage().heapUsed > 0)
     t.true(fastify.memoryUsage().rssBytes > 0)
+    t.true(fastify.memoryUsage().eventLoopUtilizationVal >= 0)
     reply.send({ hello: 'world' })
   })
 

--- a/test.js
+++ b/test.js
@@ -265,7 +265,7 @@ test('memoryUsage name space', t => {
     t.true(fastify.memoryUsage().eventLoopDelay > 0)
     t.true(fastify.memoryUsage().heapUsed > 0)
     t.true(fastify.memoryUsage().rssBytes > 0)
-    t.true(fastify.memoryUsage().eventLoopUtilizationVal >= 0)
+    t.true(fastify.memoryUsage().eventLoopUtilized >= 0)
     reply.send({ hello: 'world' })
   })
 
@@ -304,7 +304,7 @@ test('memoryUsage name space (without check)', t => {
     t.true(fastify.memoryUsage().eventLoopDelay > 0)
     t.true(fastify.memoryUsage().heapUsed > 0)
     t.true(fastify.memoryUsage().rssBytes > 0)
-    t.true(fastify.memoryUsage().eventLoopUtilizationVal >= 0)
+    t.true(fastify.memoryUsage().eventLoopUtilized >= 0)
     reply.send({ hello: 'world' })
   })
 


### PR DESCRIPTION

Adds `eventLoopUtilizationVal` to `memoryUsage` function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
