### PR TITLE
feat(expose status details): Adds route to expose status details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fastify.listen(3000, err => {
   console.log(`server listening on ${fastify.server.address().port}`)
 })
 ```
-`under-pressure` will automatically handle for you the `Service Unavailable` error once one of the thresholds has been reached.  
+`under-pressure` will automatically handle for you the `Service Unavailable` error once one of the thresholds has been reached.
 You can configure the error message and the `Retry-After` header.
 ```js
 fastify.register(require('under-pressure'), {
@@ -60,14 +60,14 @@ You can also configure custom Error instance `under-pressure` will throw.
       Error.captureStackTrace(this, CustomError)
     }
   }
-  
+
   fastify.register(require('under-pressure'), {
   maxEventLoopDelay: 1000,
   customError: CustomError
 })
 ```
 
-The default value for `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` is `0`.  
+The default value for `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` is `0`.
 If the value is `0` the check will not be performed.
 
 Since [`eventLoopUtilization`](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_utilization1_utilization2) is only available in Node version 14.0.0 and 12.19.0 the check will be disbaled in other versions.
@@ -81,7 +81,7 @@ console.log(fastify.memoryUsage())
 ```
 
 #### Status route
-If needed you can pass `{ exposeStatusRoute: true }` and `under-pressure` will expose a `/status` route for you that sends back a `{ status: 'ok' }` object. This can be useful if you need to attach the server to an ELB on AWS for example.
+If needed you can pass `{ exposeStatusRoute: true }` and `under-pressure` will expose a `/status` route for you that sends back a `{ status: 'ok' }` object. When the server is under pressure, it will return `{ status: 'not-ok' }`. This can be useful if you need to attach the server to an ELB on AWS for example.
 
 If you need the change the exposed route path, you can pass `{ exposeStatusRoute: '/alive' }` options.
 
@@ -104,6 +104,38 @@ fastify.register(require('under-pressure'), {
 })
 ```
 The above example will set the `logLevel` value for the `/status` route be `debug`.
+
+#### Status details route
+If needed you can pass `{ exposeStatusDetailsRoute: true }` and `under-pressure` will expose a `/status/details` route for you that sends back a JSON payload with the return of the `memoryUsage` function described above.
+
+If you need the change the exposed route path, you can pass `{ exposeStatusDetailsRoute: '/status-details' }` options.
+
+If you need to pass options to the status details route, such as logLevel or custom configuration you can pass an object,
+```js
+fastify.register(require('under-pressure'), {
+  maxEventLoopDelay: 1000,
+  exposeStatusDetailsRoute: {
+    routeOpts: {
+      logLevel: 'debug',
+      config: {
+        someAttr: 'value'
+      }
+    },
+    routeSchemaOpts: { // If you also want to set a custom route schema
+      hide: true
+    },
+    url: '/status-details' // If you also want to set a custom route path and pass options
+  }
+})
+```
+
+You can disable it under certain conditions, for instance:
+```js
+fastify.register(require('under-pressure'), {
+  maxEventLoopDelay: 1000,
+  exposeStatusDetailsRoute: !process.env.NODE_ENV === production
+})
+```
 
 #### Custom health checks
 If needed you can pass a custom `healthCheck` property which is an async function and `under-pressure` will allow you to check the status of other components of your service.
@@ -148,7 +180,7 @@ fastify.register(require('under-pressure'), {
 <a name="acknowledgements"></a>
 ## Acknowledgements
 
-This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).  
+This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).
 
 <a name="license"></a>
 ## License

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ fastify.listen(3000, err => {
 })
 ```
 `under-pressure` will automatically handle for you the `Service Unavailable` error once one of the thresholds has been reached.
+The status and status details routes will always return their corresponding payloads without regards of the thresholds.
 You can configure the error message and the `Retry-After` header.
 ```js
 fastify.register(require('under-pressure'), {

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ async function underPressure (fastify, opts) {
       ...opts.exposeStatusDetailsRoute.routeOpts || {},
       url: opts.exposeStatusDetailsRoute.url,
       method: 'GET',
-      schema: Object.assign({}, opts.exposeStatusRoute.routeSchemaOpts, {
+      schema: Object.assign({}, opts.exposeStatusDetailsRoute.routeSchemaOpts, {
         response: {
           200: {
             type: 'object',

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ async function underPressure (fastify, opts) {
   }
 
   fastify.decorate('memoryUsage', memoryUsage)
-  fastify.decorate('isUnderPressureError', false);
+  fastify.decorate('isUnderPressureError', false)
   fastify.addHook('onClose', onClose)
 
   opts.exposeStatusRoute = mapExposeStatusRoute(opts.exposeStatusRoute, '/status')

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ async function underPressure (fastify, opts) {
   fastify.addHook('onClose', onClose)
 
   opts.exposeStatusRoute = mapExposeStatusRoute(opts.exposeStatusRoute, '/status')
-  opts.exposeStatusMemoryUsageRoute = mapExposeStatusRoute(opts.exposeStatusMemoryUsageRoute, '/status/memory-usage')
+  opts.exposeStatusDetailsRoute = mapExposeStatusRoute(opts.exposeStatusDetailsRoute, '/status/details')
 
   if (opts.exposeStatusRoute) {
     fastify.route({
@@ -106,10 +106,10 @@ async function underPressure (fastify, opts) {
     })
   }
 
-  if (opts.exposeStatusMemoryUsageRoute) {
+  if (opts.exposeStatusDetailsRoute) {
     fastify.route({
-      ...opts.exposeStatusMemoryUsageRoute.routeOpts || {},
-      url: opts.exposeStatusMemoryUsageRoute.url,
+      ...opts.exposeStatusDetailsRoute.routeOpts || {},
+      url: opts.exposeStatusDetailsRoute.url,
       method: 'GET',
       schema: Object.assign({}, opts.exposeStatusRoute.routeSchemaOpts, {
         response: {
@@ -201,7 +201,7 @@ async function underPressure (fastify, opts) {
     if (
       [
         opts.exposeStatusRoute.url,
-        opts.exposeStatusMemoryUsageRoute.url
+        opts.exposeStatusDetailsRoute.url
       ].filter(Boolean).includes(req.url)
     ) {
       return next()

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ async function underPressure (fastify, opts) {
           }
         }
       }),
-      handler: onStatusMemoryUsage
+      handler: onStatusDetails
     })
   }
 
@@ -248,7 +248,7 @@ async function underPressure (fastify, opts) {
     return { status: 'ok' }
   }
 
-  async function onStatusMemoryUsage (req, reply) {
+  async function onStatusDetails () {
     return memoryUsage()
   }
 

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ async function underPressure (fastify, opts) {
     return { status: 'ok' }
   }
 
-  async function onStatusDetails () {
+  function onStatusDetails () {
     return memoryUsage()
   }
 


### PR DESCRIPTION
* Adds a new `/status/memory-usage` endpoint (if configured with `exposeStatusMemoryUsageRoute`), similar to `exposeStatusRoute`.
* Both routes `/status` and `/status/memory-usage` will always return a value even if the server is under pressure.
* Route `/status` returns `not-ok` when server is under pressure.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
