### PR TITLE
Fix #83: Allow custom response from healthCheck function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fastify.listen(3000, err => {
   console.log(`server listening on ${fastify.server.address().port}`)
 })
 ```
-`under-pressure` will automatically handle for you the `Service Unavailable` error once one of the thresholds has been reached.  
+`under-pressure` will automatically handle for you the `Service Unavailable` error once one of the thresholds has been reached.
 You can configure the error message and the `Retry-After` header.
 ```js
 fastify.register(require('under-pressure'), {
@@ -60,14 +60,14 @@ You can also configure custom Error instance `under-pressure` will throw.
       Error.captureStackTrace(this, CustomError)
     }
   }
-  
+
   fastify.register(require('under-pressure'), {
   maxEventLoopDelay: 1000,
   customError: CustomError
 })
 ```
 
-The default value for `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` is `0`.  
+The default value for `maxEventLoopDelay`, `maxHeapUsedBytes`, `maxRssBytes` and `maxEventLoopUtilization` is `0`.
 If the value is `0` the check will not be performed.
 
 Since [`eventLoopUtilization`](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_utilization1_utilization2) is only available in Node version 14.0.0 and 12.19.0 the check will be disbaled in other versions.
@@ -105,10 +105,30 @@ fastify.register(require('under-pressure'), {
 ```
 The above example will set the `logLevel` value for the `/status` route be `debug`.
 
+If you need to return other informations in the response, you can return an object from `healthCheck` function (see next paragraph) and use the `routeResponseSchemaOpts` property to describe your custom response schema (**note**: `status` will always be present in the response)
+
+```js
+fastify.register(underPressure, {
+  ...
+  exposeStatusRoute: {
+    routeResponseSchemaOpts: {
+      extraValue: { type: 'string' },
+      // ...
+    }
+  },
+  healthCheck: async () => {
+    return {
+      extraValue: await getExtraValue(),
+      // ...
+    }
+  },
+}
+```
+
 #### Custom health checks
 If needed you can pass a custom `healthCheck` property which is an async function and `under-pressure` will allow you to check the status of other components of your service.
 
-This function should return a promise which resolves to a boolean value. The `healthCheck` function can be called either:
+This function should return a promise which resolves to a boolean value or to an object. The `healthCheck` function can be called either:
 
 * every X milliseconds, the time can be
   configured with the `healthCheckInterval` option.
@@ -148,7 +168,7 @@ fastify.register(require('under-pressure'), {
 <a name="acknowledgements"></a>
 ## Acknowledgements
 
-This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).  
+This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).
 
 <a name="license"></a>
 ## License

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ fastify.register(require('under-pressure'), {
 ```
 The above example will set the `logLevel` value for the `/status` route be `debug`.
 
-If you need to return other informations in the response, you can return an object from `healthCheck` function (see next paragraph) and use the `routeResponseSchemaOpts` property to describe your custom response schema (**note**: `status` will always be present in the response)
+If you need to return other information in the response, you can return an object from the `healthCheck` function (see next paragraph) and use the `routeResponseSchemaOpts` property to describe your custom response schema (**note**: `status` will always be present in the response)
 
 ```js
 fastify.register(underPressure, {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace underPressure {
     healthCheck?: () => Promise<boolean>;
     healthCheckInterval?: number;
     sampleInterval?: number;
-    exposeStatusRoute?: boolean | string | { routeOpts: object; routeSchemaOpts?: object; url?: string };
+    exposeStatusRoute?: boolean | string | { routeOpts: object; routeSchemaOpts?: object; routeResponseSchemaOpts?: object; url?: string };
     customError?: Error;
   }
 }

--- a/index.js
+++ b/index.js
@@ -95,9 +95,8 @@ async function underPressure (fastify, opts) {
           200: {
             type: 'object',
             properties: Object.assign(
-              {},
-              opts.exposeStatusRoute.routeResponseSchemaOpts,
-              { status: { type: 'string' } }
+              { status: { type: 'string' } },
+              opts.exposeStatusRoute.routeResponseSchemaOpts
             )
           }
         }

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ async function underPressure (fastify, opts) {
   }
 
   async function onStatus (req, reply) {
-    let response = { status: 'ok' }
+    const response = { status: 'ok' }
     if (healthCheck) {
       try {
         const checkResult = await healthCheck()
@@ -208,11 +208,9 @@ async function underPressure (fastify, opts) {
           throw underPressureError
         }
 
-        if (typeof checkResult === 'object' && checkResult !== null && !Array.isArray(checkResult)) {
-          response = {
-            ...response,
-            ...checkResult
-          }
+        return {
+          ...response,
+          ...checkResult
         }
       } catch (err) {
         req.log.error({ err }, 'external health check failed with error')

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ async function underPressure (fastify, opts) {
   }
 
   async function onStatus (req, reply) {
-    const response = { status: 'ok' }
+    const okResponse = { status: 'ok' }
     if (healthCheck) {
       try {
         const checkResult = await healthCheck()
@@ -208,10 +208,7 @@ async function underPressure (fastify, opts) {
           throw underPressureError
         }
 
-        return {
-          ...response,
-          ...checkResult
-        }
+        return Object.assign(okResponse, checkResult)
       } catch (err) {
         req.log.error({ err }, 'external health check failed with error')
         reply.status(SERVICE_UNAVAILABLE).header('Retry-After', retryAfter)
@@ -219,7 +216,7 @@ async function underPressure (fastify, opts) {
       }
     }
 
-    return response
+    return okResponse
   }
 
   function onClose (fastify, done) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR fixes #83 

This PR gives the ability to extend the `{ status: 'ok' }` response using the result of the `healthCheck` function call.
To allow that we had also to adda new option `routeResponseSchemaOpts` to the `exposeStatusRoute` object.

To return something like 

```
{
  status: 'ok',
  extraValue: 'anotherValue'
}
```

We can configure `under-pressure` like this

```js
fastify.register(underPressure, {
  ...
  exposeStatusRoute: {
    routeResponseSchemaOpts: {
      extraValue: { type: 'string' },
    }
  },
  healthCheck: async () => {
    return {
        extraValue: 'anotherValue'
    }
  },
}
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
