### PR TITLE
fix(typescript): Allow healthCheck to return an object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare namespace underPressure {
     maxRssBytes?: number;
     message?: string;
     retryAfter?: number;
-    healthCheck?: () => Promise<boolean>;
+    healthCheck?: () => Promise<Record<string, unknown> | boolean>;
     healthCheckInterval?: number;
     pressureHandler?: (request: FastifyRequest, reply: FastifyReply, type: string, value: number | undefined) => Promise<void> | void;
     sampleInterval?: number;


### PR DESCRIPTION
Hi! This is an update to the typings of this project, that were not consistent with the docs. As per the README, the `healthCheck` function is allowed to return either a boolean, or an object (that is required in order to define `routeResponseSchemaOpts`).

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (there's no benchmark script tho)
- ~~tests and/or benchmarks are included~~
- ~~documentation is changed or added~~ 
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
