### PR TITLE
FastifyInstance as argument for healthCheck; Closes #103

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,22 @@ fastify.register(underPressure, {
   exposeStatusRoute: {
     routeResponseSchemaOpts: {
       extraValue: { type: 'string' },
+      metrics: {
+        type: 'object',
+        properties: {
+          eventLoopDelay: { type: 'number' },
+          rssBytes: { type: 'number' },
+          heapUsed: { type: 'number' },
+          eventLoopUtilized: { type: 'number' },
+        },
+      },
       // ...
     }
   },
-  healthCheck: async () => {
+  healthCheck: async (fastifyInstance) => {
     return {
       extraValue: await getExtraValue(),
+      metrics: fastifyInstance.memoryUsage(),
       // ...
     }
   },
@@ -179,7 +189,7 @@ By default when this function is supplied your service health is considered unhe
 const fastify = require('fastify')()
 
 fastify.register(require('under-pressure'), {
-  healthCheck: async function () {
+  healthCheck: async function (fastifyInstance) {
     // do some magic to check if your db connection is healthy, etc...
     return true
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import {
+  FastifyInstance,
   FastifyPlugin,
   FastifyReply,
   FastifyRequest
@@ -18,7 +19,7 @@ declare namespace underPressure {
     maxRssBytes?: number;
     message?: string;
     retryAfter?: number;
-    healthCheck?: () => Promise<boolean>;
+    healthCheck?: (fastify: FastifyInstance) => Promise<Record<string, unknown> | boolean>;
     healthCheckInterval?: number;
     pressureHandler?: (request: FastifyRequest, reply: FastifyReply, type: string, value: number | undefined) => Promise<void> | void;
     sampleInterval?: number;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -38,9 +38,9 @@ const server = fastify();
 
 () => {
   server.register(underPressure, {
-    healthCheck: async function () {
+    healthCheck: async function (fastifyInstance) {
       // do some magic to check if your db connection is healthy, etc...
-      return true;
+      return fastifyInstance.register === server.register;
     },
     healthCheckInterval: 500
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I use `under-pressure` through https://github.com/fastify/fastify-nextjs#under-pressure and isolate underPressure options in `underPressureOptions.ts`. And what's funny is I just need  `fastifyInstance.memoryUsage()` method for extends positive response. (for negative, I use `pressureHandler` and `reply.server.memoryUsage()`).

- Closes #103
- Helpful for #80-like needs

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
