### PR TITLE
docs(readme): remove snyk badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![CI](https://github.com/fastify/under-pressure/workflows/CI/badge.svg)
 [![NPM version](https://img.shields.io/npm/v/under-pressure.svg?style=flat)](https://www.npmjs.com/package/under-pressure)
-[![Known Vulnerabilities](https://snyk.io/test/github/fastify/under-pressure/badge.svg)](https://snyk.io/test/github/fastify/under-pressure)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 Measure process load with automatic handling of *"Service Unavailable"* plugin for Fastify.


### PR DESCRIPTION
 Snyk badge can be removed as the dependency-review job, which is now part of the [reusable workflow](https://github.com/fastify/workflows/blob/main/.github/workflows/plugins-ci.yml), does the same thing as Snyk. See https://github.com/fastify/fastify/issues/3883

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
