### PR TITLE
replace setInterval with a setTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,19 @@ fastify.register(require('@fastify/under-pressure'), {
 
 ```
 
+<a name="additional-information"></a>
+## Additional information
+
+<a name="set-timeout-vs-set-interval"></a>
+#### `setTimeout` vs `setInterval`
+
+Under the hood the `@fastify/under-pressure` uses the `setTimeout` method to perform its polling checks. The choice is based on the fact that we do not want to add additional pressure to the system. 
+
+In fact, it is known that `setInterval` will call repeatedly at the scheduled time regardless of whether the previous call ended or not, and if the server is already under load, this will likely increase the problem, because those `setInterval` calls will start piling up. `setTimeout`, on the other hand, is called only once and does not cause the mentioned problem.
+
+One note to consider is that because the two methods are not identical, the timer function is not guaranteed to run at exactly the same rate when the system is under pressure or running a long-running process.
+
+
 <a name="acknowledgements"></a>
 ## Acknowledgements
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function underPressure (fastify, opts) {
 
   fastify.decorate('memoryUsage', memoryUsage)
 
-  const timer = setTimeout(doMemoryUsageUpdate, sampleInterval)
+  const timer = setTimeout(beginMemoryUsageUpdate, sampleInterval)
   timer.unref()
 
   let externalsHealthy = false
@@ -82,7 +82,12 @@ async function underPressure (fastify, opts) {
     await doCheck()
 
     if (healthCheckInterval > 0) {
-      externalHealthCheckTimer = setInterval(doCheck, healthCheckInterval)
+      const beginCheck = async () => {
+        await doCheck()
+        externalHealthCheckTimer.refresh()
+      }
+
+      externalHealthCheckTimer = setTimeout(beginCheck, healthCheckInterval)
       externalHealthCheckTimer.unref()
     }
   } else {
@@ -155,7 +160,7 @@ async function underPressure (fastify, opts) {
     }
   }
 
-  function doMemoryUsageUpdate () {
+  function beginMemoryUsageUpdate () {
     updateMemoryUsage()
     timer.refresh()
   }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function underPressure (fastify, opts) {
 
   fastify.decorate('memoryUsage', memoryUsage)
 
-  const timer = setInterval(updateMemoryUsage, sampleInterval)
+  const timer = setTimeout(doMemoryUsageUpdate, sampleInterval)
   timer.unref()
 
   let externalsHealthy = false
@@ -153,6 +153,11 @@ async function underPressure (fastify, opts) {
     } else {
       eventLoopUtilized = 0
     }
+  }
+
+  function doMemoryUsageUpdate () {
+    updateMemoryUsage()
+    timer.refresh()
   }
 
   function updateMemoryUsage () {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fastify": "^4.0.0-rc.2",
     "semver": "^7.3.2",
     "simple-get": "^4.0.0",
+    "sinon": "^14.0.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.2.0",


### PR DESCRIPTION
This PR fixes https://github.com/fastify/under-pressure/issues/164 replacing the setInterval timer with setTimeout.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
