### PR TITLE
Document Default Error Responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ async function fastifyUnderPressure (fastify, opts) {
             description: 'Error Performing Health Check',
             properties: {
               message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
-              statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+              statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 500 }
             }
           },
           503: {
@@ -128,7 +128,7 @@ async function fastifyUnderPressure (fastify, opts) {
               code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
               error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
               message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
-              statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
+              statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 503 }
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -107,10 +107,29 @@ async function fastifyUnderPressure (fastify, opts) {
         response: {
           200: {
             type: 'object',
+            description: 'Health Check Succeeded',
             properties: Object.assign(
               { status: { type: 'string' } },
               opts.exposeStatusRoute.routeResponseSchemaOpts
             )
+          },
+          500: {
+            type: 'object',
+            description: 'Error Performing Health Check',
+            properties: {
+              message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
+              statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+            }
+          },
+          503: {
+            type: 'object',
+            description: 'Health Check Failed',
+            properties: {
+              code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
+              error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
+              message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
+              statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
+            }
           }
         }
       }),

--- a/test/statusRoute.test.js
+++ b/test/statusRoute.test.js
@@ -139,7 +139,7 @@ test('Expose status route with additional route options, route schema options', 
           description: 'Error Performing Health Check',
           properties: {
             message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
-            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+            statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 500 }
           }
         },
         503: {
@@ -149,7 +149,7 @@ test('Expose status route with additional route options, route schema options', 
             code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
             error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
             message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
-            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
+            statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 503 }
           }
         }
       }
@@ -195,7 +195,7 @@ test('Expose status route with additional route options, route schema options an
           description: 'Error Performing Health Check',
           properties: {
             message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
-            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+            statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 500 }
           }
         },
         503: {
@@ -205,7 +205,7 @@ test('Expose status route with additional route options, route schema options an
             code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
             error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
             message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
-            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
+            statusCode: { type: 'number', description: 'Code representing the error. Always matches the HTTP response code.', example: 503 }
           }
         }
       }

--- a/test/statusRoute.test.js
+++ b/test/statusRoute.test.js
@@ -129,8 +129,27 @@ test('Expose status route with additional route options, route schema options', 
       response: {
         200: {
           type: 'object',
+          description: 'Health Check Succeeded',
           properties: {
             status: { type: 'string' }
+          }
+        },
+        500: {
+          type: 'object',
+          description: 'Error Performing Health Check',
+          properties: {
+            message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
+            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+          }
+        },
+        503: {
+          type: 'object',
+          description: 'Health Check Failed',
+          properties: {
+            code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
+            error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
+            message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
+            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
           }
         }
       }
@@ -166,8 +185,27 @@ test('Expose status route with additional route options, route schema options an
       response: {
         200: {
           type: 'object',
+          description: 'Health Check Succeeded',
           properties: {
             status: { type: 'string' }
+          }
+        },
+        500: {
+          type: 'object',
+          description: 'Error Performing Health Check',
+          properties: {
+            message: { type: 'string', description: 'Error message for failure during health check', example: 'Internal Server Error' },
+            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 500 }
+          }
+        },
+        503: {
+          type: 'object',
+          description: 'Health Check Failed',
+          properties: {
+            code: { type: 'string', description: 'Error code associated with the failing check', example: 'FST_UNDER_PRESSURE' },
+            error: { type: 'string', description: 'Error thrown during health check', example: 'Service Unavailable' },
+            message: { type: 'string', description: 'Error message to explain health check failure', example: 'Service Unavailable' },
+            statusCode: { type: 'number', description: 'Code representing the error. Currently matches the HTTP response code.', example: 503 }
           }
         }
       }


### PR DESCRIPTION
Include documentation for 500 & 503 responses in default schema definition

This ensures that they get included in the Open API documentation generated.

- chore: update tests to match updated responses

#### Demo / Screenshots

|Before|After|
|---|---|
|<img width="1445" alt="screenshot-20230710_140757" src="https://github.com/fastify/under-pressure/assets/1861055/446703c6-00a7-4cff-a501-a05a5602a786">|![under-pressure-after-adding-503-docs-resized](https://github.com/fastify/under-pressure/assets/1861055/50ae72c6-37fb-4e13-8a23-3c813a7fe9c4) |


#### Notes to Reviewer(s)

- Addition of docs for other responses make for more complete API documentation when using the healthcheck feature
- Open to suggestions on wording of descriptions
- Try out the updated documentation version here: [muya/fastify-under-pressure-update-demo](https://github.com/muya/fastify-under-pressure-update-demo)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
