### PR TITLE
Add fastify.isUnderPressure()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ external resources.
 <a name="requirements"></a>
 ## Requirements
 
-Fastify ^2.0.0. Please refer to [this branch](https://github.com/fastify/under-pressure/tree/1.x) and related versions for Fastify ^1.1.0 compatibility.
+Fastify ^4.0.0. Please refer to [this branch](https://github.com/fastify/under-pressure/tree/1.x) and related versions for Fastify ^1.1.0 compatibility.
 
 <a name="install"></a>
 ## Install
@@ -35,6 +35,9 @@ fastify.register(require('@fastify/under-pressure'), {
 })
 
 fastify.get('/', (req, reply) => {
+  if (fastify.isUnderPressure()) {
+    // skip complex computation
+  }
   reply.send({ hello: 'world'})
 })
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ async function fastifyUnderPressure (fastify, opts) {
   }
 
   fastify.decorate('memoryUsage', memoryUsage)
+  fastify.decorate('isUnderPressure', isUnderPressure)
 
   const timer = setTimeout(beginMemoryUsageUpdate, sampleInterval)
   timer.unref()
@@ -171,6 +172,30 @@ async function fastifyUnderPressure (fastify, opts) {
     rssBytes = mem.rss
     updateEventLoopDelay()
     updateEventLoopUtilization()
+  }
+
+  function isUnderPressure () {
+    if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
+      return true
+    }
+
+    if (checkMaxHeapUsedBytes && heapUsed > maxHeapUsedBytes) {
+      return true
+    }
+
+    if (checkMaxRssBytes && rssBytes > maxRssBytes) {
+      return true
+    }
+
+    if (!externalsHealthy) {
+      return true
+    }
+
+    if (checkMaxEventLoopUtilization && eventLoopUtilized > maxEventLoopUtilization) {
+      return true
+    }
+
+    return false
   }
 
   function onRequest (req, reply, next) {

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ const { valid, satisfies, coerce } = require('semver')
 const wait = promisify(setTimeout)
 
 test('Should return 503 on maxEventLoopDelay', t => {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(underPressure, {
@@ -42,6 +42,7 @@ test('Should return 503 on maxEventLoopDelay', t => {
         message: 'Service Unavailable',
         statusCode: 503
       })
+      t.equal(fastify.isUnderPressure(), true)
       fastify.close()
     })
 
@@ -51,7 +52,7 @@ test('Should return 503 on maxEventLoopDelay', t => {
 
 const isSupportedVersion = satisfies(valid(coerce(process.version)), '12.19.0 || >=14.0.0')
 test('Should return 503 on maxEventloopUtilization', { skip: !isSupportedVersion }, t => {
-  t.plan(5)
+  t.plan(6)
   const fastify = Fastify()
   fastify.register(underPressure, {
     maxEventLoopUtilization: 0.60
@@ -75,6 +76,7 @@ test('Should return 503 on maxEventloopUtilization', { skip: !isSupportedVersion
         message: 'Service Unavailable',
         statusCode: 503
       })
+      t.equal(fastify.isUnderPressure(), true)
       fastify.close()
     })
 
@@ -83,7 +85,7 @@ test('Should return 503 on maxEventloopUtilization', { skip: !isSupportedVersion
 })
 
 test('Should return 503 on maxHeapUsedBytes', t => {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(underPressure, {
@@ -108,6 +110,7 @@ test('Should return 503 on maxHeapUsedBytes', t => {
         message: 'Service Unavailable',
         statusCode: 503
       })
+      t.equal(fastify.isUnderPressure(), true)
       fastify.close()
     })
 
@@ -116,7 +119,7 @@ test('Should return 503 on maxHeapUsedBytes', t => {
 })
 
 test('Should return 503 on maxRssBytes', t => {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(underPressure, {
@@ -141,6 +144,7 @@ test('Should return 503 on maxRssBytes', t => {
         message: 'Service Unavailable',
         statusCode: 503
       })
+      t.equal(fastify.isUnderPressure(), true)
       fastify.close()
     })
 
@@ -231,7 +235,7 @@ test('Custom error instance', t => {
 })
 
 test('memoryUsage name space', t => {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = Fastify()
   fastify.register(underPressure, {
@@ -264,6 +268,7 @@ test('memoryUsage name space', t => {
       t.error(err)
       t.equal(response.statusCode, 200)
       t.same(JSON.parse(body), { hello: 'world' })
+      t.equal(fastify.isUnderPressure(), true)
       fastify.close()
     })
 
@@ -311,7 +316,7 @@ test('Custom health check', t => {
   t.plan(8)
 
   t.test('should return 503 when custom health check returns false for healthCheck', t => {
-    t.plan(5)
+    t.plan(6)
 
     const fastify = Fastify()
     fastify.register(underPressure, {
@@ -339,6 +344,7 @@ test('Custom health check', t => {
           message: 'Service Unavailable',
           statusCode: 503
         })
+        t.equal(fastify.isUnderPressure(), true)
         fastify.close()
       })
     })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ import {
 declare module "fastify" {
   interface FastifyInstance {
     memoryUsage(): { heapUsed: number; rssBytes: number; eventLoopDelay: number; eventLoopUtilized: number };
+    isUnderPressure(): boolean;
   }
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -14,7 +14,8 @@ const server = fastify();
   server.register(fastifyUnderPressure);
 
   server.get("/", (req, reply) => {
-    reply.send({ hello: "world" });
+
+    reply.send({ hello: "world", underPressure: server.isUnderPressure() });
   });
 
   server.listen({port: 3000}, err => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR adds a decorated function to check if the current application is under pressure. This will allow applications to skip complex computations in that case (and possibly return an error).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
