### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 
 const fe = require('@fastify/error')
 const fp = require('fastify-plugin')
-const assert = require('assert')
-const { monitorEventLoopDelay } = require('perf_hooks')
-const { eventLoopUtilization } = require('perf_hooks').performance
+const assert = require('node:assert')
+const { monitorEventLoopDelay } = require('node:perf_hooks')
+const { eventLoopUtilization } = require('node:perf_hooks').performance
 
 const SERVICE_UNAVAILABLE = 503
 const createError = (msg = 'Service Unavailable') => fe('FST_UNDER_PRESSURE', msg, SERVICE_UNAVAILABLE)

--- a/test/forkRequest.js
+++ b/test/forkRequest.js
@@ -1,5 +1,5 @@
-const fork = require('child_process').fork
-const resolve = require('path').resolve
+const fork = require('node:child_process').fork
+const resolve = require('node:path').resolve
 
 module.exports = function forkRequest (address, delay = 100, cb) {
   const childProcess = fork(

--- a/test/pressurehandler.test.js
+++ b/test/pressurehandler.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const { test } = require('tap')
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const forkRequest = require('./forkRequest')
 const Fastify = require('fastify')
-const { monitorEventLoopDelay } = require('perf_hooks')
+const { monitorEventLoopDelay } = require('node:perf_hooks')
 const underPressure = require('../index')
 const { valid, satisfies, coerce } = require('semver')
 const sinon = require('sinon')

--- a/test/request.js
+++ b/test/request.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const sget = require('simple-get').concat
-const promisify = require('util').promisify
+const promisify = require('node:util').promisify
 const wait = promisify(setTimeout)
 
 const address = process.argv[2]

--- a/test/statusRoute.test.js
+++ b/test/statusRoute.test.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const forkRequest = require('./forkRequest')
 const Fastify = require('fastify')
-const { monitorEventLoopDelay } = require('perf_hooks')
+const { monitorEventLoopDelay } = require('node:perf_hooks')
 const underPressure = require('../index')
 
 function block (msec) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const { test } = require('tap')
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const forkRequest = require('./forkRequest')
 const Fastify = require('fastify')
-const { monitorEventLoopDelay } = require('perf_hooks')
+const { monitorEventLoopDelay } = require('node:perf_hooks')
 const underPressure = require('../index')
 const { valid, satisfies, coerce } = require('semver')
 


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
