### PR TITLE
docs(readme): replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you need the change the exposed route path, you can pass `{ exposeStatusRoute
 
 To configure the endpoint more specifically you can pass an object. This consists of
 
-- *routeOpts* - Any Fastify [route options](https://www.fastify.io/docs/latest/Reference/Routes/#routes-options) except `schema`
+- *routeOpts* - Any Fastify [route options](https://www.fastify.dev/docs/latest/Reference/Routes/#routes-options) except `schema`
 - *routeSchemaOpts* - As per the Fastify route options, an object containing the schema for request
 - *routeResponseSchemaOpts* - An object containing the schema for additional response items to be merged with the default response schema, see below
 - *url* - The URL to expose the status route on

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you need the change the exposed route path, you can pass `{ exposeStatusRoute
 
 To configure the endpoint more specifically you can pass an object. This consists of
 
-- *routeOpts* - Any Fastify [route options](https://www.fastify.dev/docs/latest/Reference/Routes/#routes-options) except `schema`
+- *routeOpts* - Any Fastify [route options](https://fastify.dev/docs/latest/Reference/Routes/#routes-options) except `schema`
 - *routeSchemaOpts* - As per the Fastify route options, an object containing the schema for request
 - *routeResponseSchemaOpts* - An object containing the schema for additional response items to be merged with the default response schema, see below
 - *url* - The URL to expose the status route on


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
