### PR TITLE
fix: [FSTDEP012] DeprecationWarning: request.context property access is deprecated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ async function fastifyUnderPressure (fastify, opts) {
   }
 
   function onRequest (req, reply, next) {
-    const _pressureHandler = req.context.config.pressureHandler || pressureHandler
+    const _pressureHandler = req.routeOptions.config.pressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)
       return


### PR DESCRIPTION
With mot recent Fastify v4.x releases, we get this:

```
[FSTDEP012] DeprecationWarning: request.context property access is deprecated. Please use "request.routeOptions.config" or "request.routeOptions.schema" instead for accessing Route settings. The "request.context" will be removed in `fastify@5`.
```

This is already fixed in [master](https://github.com/fastify/under-pressure/commit/a650100e38ab1e4f8f9bcd305b50ef4a087fa7bf#). 

If this work we can have a 8.x release to address the problem without waiting for the new 9.x release.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
