### PR TITLE
fix: handle missing route options

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,9 @@ async function fastifyUnderPressure (fastify, opts) {
   }
 
   function onRequest (req, reply, next) {
-    const _pressureHandler = req.routeOptions.config.pressureHandler || pressureHandler
+    const options = req.routeOptions ? req.routeOptions : req.context
+    const reqPressureHandler = options.config.pressureHandler
+    const _pressureHandler = reqPressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)
       return

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ async function fastifyUnderPressure (fastify, opts) {
   }
 
   function onRequest (req, reply, next) {
-    const config = req.routeOptions && req.routeOptions.config ? req.routeOptions.config : req.context.config
+    const config = req?.routeOptions?.config ?? req.context.config
     const _pressureHandler = config.pressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)

--- a/index.js
+++ b/index.js
@@ -220,16 +220,8 @@ async function fastifyUnderPressure (fastify, opts) {
     return false
   }
 
-  function getReqConfig(req) {
-    if (req.routeOptions && req.routeOptions.config) {
-      return req.routeOptions.config
-    }
-
-    return req.context.config
-  }
-
   function onRequest (req, reply, next) {
-    const config = getReqConfig(req)
+    const config = req.routeOptions && req.routeOptions.config ? req.routeOptions.config : req.context.config
     const _pressureHandler = config.pressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)

--- a/index.js
+++ b/index.js
@@ -220,10 +220,17 @@ async function fastifyUnderPressure (fastify, opts) {
     return false
   }
 
+  function getReqConfig(req) {
+    if (req.routeOptions && req.routeOptions.config) {
+      return req.routeOptions.config
+    }
+
+    return req.context.config
+  }
+
   function onRequest (req, reply, next) {
-    const options = req.routeOptions ? req.routeOptions : req.context
-    const reqPressureHandler = options.config.pressureHandler
-    const _pressureHandler = reqPressureHandler || pressureHandler
+    const config = getReqConfig(req)
+    const _pressureHandler = config.pressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)
       return

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ async function fastifyUnderPressure (fastify, opts) {
   }
 
   function onRequest (req, reply, next) {
-    const config = req?.routeOptions?.config ?? req.context.config
+    const config = req.routeOptions?.config ?? req.context.config
     const _pressureHandler = config.pressureHandler || pressureHandler
     if (checkMaxEventLoopDelay && eventLoopDelay > maxEventLoopDelay) {
       handlePressure(_pressureHandler, req, reply, next, TYPE_EVENT_LOOP_DELAY, eventLoopDelay)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "fastify": "^4.0.0-rc.2",
+    "fastify": "^4.0.0",
     "semver": "^7.3.2",
     "simple-get": "^4.0.0",
     "sinon": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "fastify": "^4.0.0",
+    "fastify": "^4.0.0-rc.2",
     "semver": "^7.3.2",
     "simple-get": "^4.0.0",
     "sinon": "^18.0.0",


### PR DESCRIPTION
Fixes #232 

in fastify < 4.10  req in onRequest hook didn't have `routeOptions` at all - [PR](https://github.com/fastify/fastify/pull/4397)
in fastify < 4.23 `routeOptions` didn't have `config` property - [PR](https://github.com/fastify/fastify/pull/4470)

I handled both cases to keep compatibility, but I don't know how add tests for it. Do you have any suggestions?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
