### PR TITLE
chore(package): add homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/fastify/under-pressure/issues"
   },
+  "homepage": "https://github.com/fastify/under-pressure#readme",
   "keywords": [
     "fastify",
     "service unavailable",


### PR DESCRIPTION
Added the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property to allow for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![image](https://github.com/user-attachments/assets/c87d101d-0cd5-4ff4-94b2-9df20c0d4467)

Compared to `@fastify/bearer-auth`, which [does have the homepage set](https://github.com/fastify/fastify-bearer-auth/blob/8baba0eb1ab5d0d9f5da2de7338461c2ef3ed727/package.json#L32):

![image](https://github.com/user-attachments/assets/6e6a9a5c-80ab-4eeb-9168-4178ba4d2e4a)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
