### PR TITLE
refactor(types): migrate from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "borp -C --check-coverage --reporter=@jsumners/line-reporter",
-    "test:typescript": "tsd"
+    "test:typescript": "tstyche"
   },
   "repository": {
     "type": "git",
@@ -72,7 +72,7 @@
     "proxyquire": "^2.1.3",
     "semver": "^7.6.0",
     "sinon": "^18.0.0",
-    "tsd": "^0.33.0"
+    "tstyche": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,6 +1,6 @@
-import fastifyUnderPressure, { fastifyUnderPressure as namedFastifyUnderPressure, TYPE_EVENT_LOOP_DELAY, TYPE_EVENT_LOOP_UTILIZATION, TYPE_HEALTH_CHECK, TYPE_HEAP_USED_BYTES, TYPE_RSS_BYTES } from '..'
+import fastifyUnderPressure, { fastifyUnderPressure as namedFastifyUnderPressure, TYPE_EVENT_LOOP_DELAY, TYPE_EVENT_LOOP_UTILIZATION, TYPE_HEALTH_CHECK, TYPE_HEAP_USED_BYTES, TYPE_RSS_BYTES } from '.'
 import fastify from 'fastify'
-import { expectType } from 'tsd'
+import { expect } from 'tstyche'
 
 {
   const server = fastify()
@@ -111,20 +111,20 @@ import { expectType } from 'tsd'
   })
 }
 
-expectType<'eventLoopDelay'>(fastifyUnderPressure.TYPE_EVENT_LOOP_DELAY)
-expectType<'heapUsedBytes'>(fastifyUnderPressure.TYPE_HEAP_USED_BYTES)
-expectType<'rssBytes'>(fastifyUnderPressure.TYPE_RSS_BYTES)
-expectType<'healthCheck'>(fastifyUnderPressure.TYPE_HEALTH_CHECK)
-expectType<'eventLoopUtilization'>(fastifyUnderPressure.TYPE_EVENT_LOOP_UTILIZATION)
+expect(fastifyUnderPressure.TYPE_EVENT_LOOP_DELAY).type.toBe<'eventLoopDelay'>()
+expect(fastifyUnderPressure.TYPE_HEAP_USED_BYTES).type.toBe<'heapUsedBytes'>()
+expect(fastifyUnderPressure.TYPE_RSS_BYTES).type.toBe<'rssBytes'>()
+expect(fastifyUnderPressure.TYPE_HEALTH_CHECK).type.toBe<'healthCheck'>()
+expect(fastifyUnderPressure.TYPE_EVENT_LOOP_UTILIZATION).type.toBe<'eventLoopUtilization'>()
 
-expectType<'eventLoopDelay'>(namedFastifyUnderPressure.TYPE_EVENT_LOOP_DELAY)
-expectType<'heapUsedBytes'>(namedFastifyUnderPressure.TYPE_HEAP_USED_BYTES)
-expectType<'rssBytes'>(namedFastifyUnderPressure.TYPE_RSS_BYTES)
-expectType<'healthCheck'>(namedFastifyUnderPressure.TYPE_HEALTH_CHECK)
-expectType<'eventLoopUtilization'>(namedFastifyUnderPressure.TYPE_EVENT_LOOP_UTILIZATION)
+expect(namedFastifyUnderPressure.TYPE_EVENT_LOOP_DELAY).type.toBe<'eventLoopDelay'>()
+expect(namedFastifyUnderPressure.TYPE_HEAP_USED_BYTES).type.toBe<'heapUsedBytes'>()
+expect(namedFastifyUnderPressure.TYPE_RSS_BYTES).type.toBe<'rssBytes'>()
+expect(namedFastifyUnderPressure.TYPE_HEALTH_CHECK).type.toBe<'healthCheck'>()
+expect(namedFastifyUnderPressure.TYPE_EVENT_LOOP_UTILIZATION).type.toBe<'eventLoopUtilization'>()
 
-expectType<'eventLoopDelay'>(TYPE_EVENT_LOOP_DELAY)
-expectType<'heapUsedBytes'>(TYPE_HEAP_USED_BYTES)
-expectType<'rssBytes'>(TYPE_RSS_BYTES)
-expectType<'healthCheck'>(TYPE_HEALTH_CHECK)
-expectType<'eventLoopUtilization'>(TYPE_EVENT_LOOP_UTILIZATION)
+expect(TYPE_EVENT_LOOP_DELAY).type.toBe<'eventLoopDelay'>()
+expect(TYPE_HEAP_USED_BYTES).type.toBe<'heapUsedBytes'>()
+expect(TYPE_RSS_BYTES).type.toBe<'rssBytes'>()
+expect(TYPE_HEALTH_CHECK).type.toBe<'healthCheck'>()
+expect(TYPE_EVENT_LOOP_UTILIZATION).type.toBe<'eventLoopUtilization'>()


### PR DESCRIPTION
Proposal:

- migrate from `tsd` to `tstyche`

PR of Reference: 
  - https://github.com/fastify/fastify/pull/6532
  - https://github.com/fastify/fastify/pull/6525

