### PR TITLE
fix(test): explicit toFake to avoid faking nextTick with sinon

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "neostandard": "^0.13.0",
     "proxyquire": "^2.1.3",
     "semver": "^7.6.0",
-    "sinon": "^18.0.0",
+    "sinon": "^22.0.0",
     "tstyche": "^7.0.0"
   },
   "publishConfig": {

--- a/test/pressurehandler.test.js
+++ b/test/pressurehandler.test.js
@@ -105,7 +105,9 @@ describe('health check', async () => {
   })
 
   test('interval reentrance', async () => {
-    const clock = sinon.useFakeTimers()
+    const clock = sinon.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date']
+    })
     after(() => sinon.restore())
 
     const healthCheckInterval = 500


### PR DESCRIPTION
Proposal:

- `@sinonjs/fake-timers` v13 (shipped with sinon v19) now fakes `process.nextTick` and `queueMicrotask` by default. This caused `fastify.ready()` to deadlock in the "interval reentrance" test because Fastify's boot cycle relies on `process.nextTick` internally. Pass an explicit `toFake` list to `sinon.useFakeTimers()` so that only the timer APIs actually needed by the test are replaced, leaving `process.nextTick` and `queueMicrotask` untouched.
- Bumps sinon to v22

With this solution, you can safely upgrade to the new versions of sinon: 19, 20, 21, and 22.

This PR should close this PR: https://github.com/fastify/under-pressure/pull/286