### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "delay",
     "retry"
   ],
-  "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
+  "author": "Tomas Della Vedova - @delvedor (https://delvedor.dev)",
   "contributors": [
     {
       "name": "Matteo Collina",


### PR DESCRIPTION
Old link no longer exists