### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ One note to consider is that because the two methods are not identical, the time
 <a name="acknowledgments"></a>
 ## Acknowledgments
 
-This project is kindly sponsored by [LetzDoIt](https://www.letzdoitapp.com/).
+Past sponsors:
+- LetzDoIt
 
 <a name="license"></a>
 ## License


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71